### PR TITLE
Scheme layout controllable from admin panel

### DIFF
--- a/communityEmpowerment/admin.py
+++ b/communityEmpowerment/admin.py
@@ -6,11 +6,11 @@ from django.contrib.auth.models import Group, Permission
 from .models import (
     State, Department, Organisation, Scheme, Beneficiary, SchemeBeneficiary, 
     Benefit, Criteria, Procedure, Document, SchemeDocument, Sponsor, ProfileField, ProfileFieldChoice, ProfileFieldValue, CustomUser,
-    SchemeSponsor, CustomUser, Banner, Tag, SchemeReport, WebsiteFeedback, SchemeFeedback,
+    SchemeSponsor, CustomUser, Banner, Tag, SchemeReport, WebsiteFeedback, SchemeFeedback, LayoutItem
 )
 from django.db.models import Count
 from django.db.models import Min
-
+from orderable.admin import OrderableAdmin
 
 admin.site.site_header = "Community Empowerment Portal Admin Panel"
 admin.site.site_title = "Admin Portal"
@@ -190,3 +190,12 @@ class CustomUserAdmin(UserAdmin):
 
 
 admin.site.register(CustomUser, CustomUserAdmin)
+
+
+class LayoutItemAdmin(admin.ModelAdmin):
+    list_display = ("column_name", "order")
+    ordering = ("order",)
+
+admin.site.register(LayoutItem, LayoutItemAdmin)
+
+

--- a/communityEmpowerment/models.py
+++ b/communityEmpowerment/models.py
@@ -9,6 +9,7 @@ from django.conf import settings
 from django.core.exceptions import ValidationError
 import re
 from dirtyfields import DirtyFieldsMixin
+from orderable.models import Orderable
 
 from storages.backends.s3boto3 import S3Boto3Storage
 
@@ -754,3 +755,21 @@ class UserEvent(models.Model):
 
     def __str__(self):
         return f"{self.user} - {self.event_type} - {self.scheme.title}"
+
+
+class LayoutItem(models.Model):
+    COLUMN_CHOICES = [
+        ("schemes", "Schemes"),
+        ("scholarships", "Scholarships"),
+        ("jobs", "Jobs"),
+    ]
+    
+    column_name = models.CharField(max_length=20, choices=COLUMN_CHOICES, unique=True)
+    order = models.IntegerField(default=0)  
+
+    class Meta:
+        ordering = ["order"] 
+
+    def __str__(self):
+        return self.get_column_name_display()
+

--- a/communityEmpowerment/serializers.py
+++ b/communityEmpowerment/serializers.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 from .models import (State, Department, Organisation, Scheme, Beneficiary, SchemeBeneficiary, Benefit, Criteria
-                     , Procedure, Document, SchemeDocument, Sponsor, SchemeSponsor, CustomUser,Banner, SavedFilter,
+                     , Procedure, Document, SchemeDocument, Sponsor, SchemeSponsor, CustomUser,Banner, SavedFilter, LayoutItem,
                       SchemeReport, WebsiteFeedback, Tag, UserInteraction, SchemeFeedback, UserEvent, ProfileField, ProfileFieldChoice, ProfileFieldValue )
 from django.utils import timezone
 from django.core.mail import EmailMessage
@@ -580,3 +580,9 @@ class CustomUserSerializer(serializers.ModelSerializer):
             dynamic_field_value.save()
 
         return user
+
+
+class LayoutItemSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = LayoutItem
+        fields = ["id", "column_name", "order"]

--- a/communityEmpowerment/urls.py
+++ b/communityEmpowerment/urls.py
@@ -67,8 +67,8 @@ from .views import (
     SchemeFeedbackCreateView,
     SchemeFeedbackListView,
     TrackEventView,
-    AllProfileFieldsView
-    
+    AllProfileFieldsView,
+    LayoutItemViewSet
 
 )
 
@@ -146,4 +146,6 @@ urlpatterns = [
     path('feedback/create/', SchemeFeedbackCreateView.as_view(), name='scheme-feedback-create'),
     path('track-event/', TrackEventView.as_view(), name='track_event'),
     path('dynamic-fields/', AllProfileFieldsView.as_view(), name='all_dynamic_fields'),
+    path("layout-items/", LayoutItemViewSet.as_view({"get": "list"}), name="layout-items-list"),
+    path("layout-items/update-order/", LayoutItemViewSet.as_view({"post": "update_order"}), name="layout-items-update"),
 ]


### PR DESCRIPTION
Added Layout item table where admin can order schemes/Scholarship/jobOpening tabs from the admin panel. and frontend team can use this endpoint `http://{domain_name}/api/layout-items/` to get the order. The response format of the endpoint will be like this. `[
    {
        "id": 1,
        "column_name": "schemes",
        "order": 1
    },
    {
        "id": 3,
        "column_name": "jobs",
        "order": 2
    },
    {
        "id": 2,
        "column_name": "scholarships",
        "order": 3
    }
]`.